### PR TITLE
fix el5-asm-compat.patch

### DIFF
--- a/patches/el5-asm-compat.patch
+++ b/patches/el5-asm-compat.patch
@@ -1,0 +1,21 @@
+diff --git patches/asm-compat.patch patches/asm-compat.patch
+new file mode 100644
+index 0000000..2370776
+--- /dev/null
++++ patches/asm-compat.patch
+@@ -0,0 +1,15 @@
++diff -ru mariadb-10.1.9.orig/include/my_context.h mariadb-10.1.9/include/my_context.h
++--- mariadb-10.1.9.orig/include/my_context.h   2015-11-20 17:08:02.000000000 -0800
+++++ mariadb-10.1.9/include/my_context.h        2016-01-27 00:26:50.000000000 -0800
++@@ -27,8 +27,10 @@
++ 
++ #ifdef __WIN__
++ #define MY_CONTEXT_USE_WIN32_FIBERS 1
++-#elif defined(__GNUC__) && __GNUC__ >= 3 && defined(__x86_64__) && !defined(__ILP32__)
+++#elif defined(__clang__)
++ #define MY_CONTEXT_USE_X86_64_GCC_ASM
+++#elif defined(__GNUC__) && __GNUC__ >= 3 && defined(__x86_64__) && !defined(__ILP32__)
+++#define MY_CONTEXT_USE_UCONTEXT
++ #elif defined(__GNUC__) && __GNUC__ >= 3 && defined(__i386__)
++ #define MY_CONTEXT_USE_I386_GCC_ASM
++ #elif defined(HAVE_UCONTEXT)

--- a/patches/el5-asm-compat.patch
+++ b/patches/el5-asm-compat.patch
@@ -1,21 +1,15 @@
-diff --git patches/asm-compat.patch patches/asm-compat.patch
-new file mode 100644
-index 0000000..2370776
---- /dev/null
-+++ patches/asm-compat.patch
-@@ -0,0 +1,15 @@
-+diff -ru mariadb-10.1.9.orig/include/my_context.h mariadb-10.1.9/include/my_context.h
-+--- mariadb-10.1.9.orig/include/my_context.h   2015-11-20 17:08:02.000000000 -0800
-++++ mariadb-10.1.9/include/my_context.h        2016-01-27 00:26:50.000000000 -0800
-+@@ -27,8 +27,10 @@
-+ 
-+ #ifdef __WIN__
-+ #define MY_CONTEXT_USE_WIN32_FIBERS 1
-+-#elif defined(__GNUC__) && __GNUC__ >= 3 && defined(__x86_64__) && !defined(__ILP32__)
-++#elif defined(__clang__)
-+ #define MY_CONTEXT_USE_X86_64_GCC_ASM
-++#elif defined(__GNUC__) && __GNUC__ >= 3 && defined(__x86_64__) && !defined(__ILP32__)
-++#define MY_CONTEXT_USE_UCONTEXT
-+ #elif defined(__GNUC__) && __GNUC__ >= 3 && defined(__i386__)
-+ #define MY_CONTEXT_USE_I386_GCC_ASM
-+ #elif defined(HAVE_UCONTEXT)
+diff -ru mariadb-10.1.9.orig/include/my_context.h mariadb-10.1.9/include/my_context.h
+--- mariadb-10.1.9.orig/include/my_context.h   2015-11-20 17:08:02.000000000 -0800
++++ mariadb-10.1.9/include/my_context.h        2016-01-27 00:26:50.000000000 -0800
+@@ -27,8 +27,10 @@
+ 
+ #ifdef __WIN__
+ #define MY_CONTEXT_USE_WIN32_FIBERS 1
+-#elif defined(__GNUC__) && __GNUC__ >= 3 && defined(__x86_64__) && !defined(__ILP32__)
++#elif defined(__clang__)
+ #define MY_CONTEXT_USE_X86_64_GCC_ASM
++#elif defined(__GNUC__) && __GNUC__ >= 3 && defined(__x86_64__) && !defined(__ILP32__)
++#define MY_CONTEXT_USE_UCONTEXT
+ #elif defined(__GNUC__) && __GNUC__ >= 3 && defined(__i386__)
+ #define MY_CONTEXT_USE_I386_GCC_ASM
+ #elif defined(HAVE_UCONTEXT)

--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,14 +1,34 @@
-# EupsPkg config file. Sourced by 'eupspkg'
+#!/usr/bin/env bash
 
 config()
 {
-    # Disable external SSL on OS X as it is not a standard library
-    # and LSST does not need full SSL support.
-    ssloptions=""
-    if [[ $(uname) == Darwin ]]; then
-        ssloptions="-DWITH_SSL=bundled"
-    fi
 
+    ARGS=()
+
+    ARGS+=("-DCMAKE_INSTALL_PREFIX=${PREFIX}")
     # TokuDB requires third-party software jemalloci (see http://www.canonware.com/jemalloc/)
-    cmake . -DCMAKE_INSTALL_PREFIX=${PREFIX} -DPLUGIN_TOKUDB=NO $ssloptions
+    ARGS+=('-DPLUGIN_TOKUDB=NO')
+
+    case $(uname) in
+        Linux*)
+            if grep -q -i "CentOS release 5" /etc/redhat-release; then
+                # mroonga does not build on EL5 (conda ref platform) and is
+                # unused by LSST
+                ARGS+=('-DPLUGIN_MROONGA=NO')
+                # required to build on EL5
+                ARGS+=('-DHAVE_CXX_NEW=NO')
+            fi
+            ;;
+        Darwin*)
+            # Disable external SSL on OS X as it is not a standard library
+            # and LSST does not need full SSL support.
+            ARGS+=('-DWITH_SSL=bundled')
+            ;;
+        *)
+            # non-fatal
+            echo "unsupported platform: $(uname)"
+            ;;
+    esac
+
+    cmake . "${ARGS[@]}"
 }

--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -2,6 +2,13 @@
 
 config()
 {
+    # Disable external SSL on OS X as it is not a standard library
+    # and LSST does not need full SSL support.
+    ssloptions=""
+    if [[ $(uname) == Darwin ]]; then
+        ssloptions="-DWITH_SSL=bundled"
+    fi
+
     # TokuDB requires third-party software jemalloci (see http://www.canonware.com/jemalloc/)
-    cmake . -DCMAKE_INSTALL_PREFIX=${PREFIX} -DPLUGIN_TOKUDB=NO
+    cmake . -DCMAKE_INSTALL_PREFIX=${PREFIX} -DPLUGIN_TOKUDB=NO $ssloptions
 }


### PR DESCRIPTION
Bad migration from conda-lsst.  Format was a patch-in-patch... creating
the patch is not as useful as applying it.
