### PR TITLE
Disable cmake cleverness with boost > v1.70

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -7,6 +7,9 @@ config()
 
     ARGS+=("-DCMAKE_INSTALL_PREFIX=${PREFIX}")
 
+    # Don't pick up e.g. conda boost by accident
+    ARGS+=("-DBoost_NO_BOOST_CMAKE=ON")
+
     # Remove mysql-test directory (~330 MB) to reduce installation size
     ARGS+=("-DINSTALL_MYSQLTESTDIR=")
 


### PR DESCRIPTION
Prevent cmake from using conda version of boost when building maradb (server) package.